### PR TITLE
Extend cache lifetime by a lot

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 timeout: 1500s
 steps:
 - name: 'gcr.io/kaniko-project/executor'
-  args: ['--destination=gcr.io/irc-246305/rustbucket:$SHORT_SHA', '--cache=true', '--cache-ttl=12h']
+  args: ['--destination=gcr.io/irc-246305/rustbucket:$SHORT_SHA', '--cache=true', '--cache-ttl=999h']
   timeout: 1200s


### PR DESCRIPTION
Honestly cache could live forever, because it's caching
deps and that's downstream of Cargo.{lock,toml}